### PR TITLE
Fixed missing flags for vehicle frames

### DIFF
--- a/data/json/vehicleparts/frames.json
+++ b/data/json/vehicleparts/frames.json
@@ -74,10 +74,11 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
     },
+    "flags": [ "MOUNTABLE", "INITIAL_PART" ],
     "damage_reduction": { "all": 52 }
   },
   {
-    "abstract": "frame_wood_light",
+    "id": "frame_wood_light",
     "type": "vehicle_part",
     "name": { "str": "light wooden frame" },
     "item": "frame_wood_light",
@@ -92,6 +93,7 @@
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "10 m", "using": [ [ "rope_natural_short", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 0 ] ], "time": "5 m", "using": [ [ "adhesive", 1 ] ] }
     },
+    "flags": [ "MOUNTABLE", "INITIAL_PART" ],
     "damage_reduction": { "all": 46 }
   },
   {
@@ -129,7 +131,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": "vehicle_weld_removal" },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "welding_standard", 10 ] ] }
     },
-    "flags": [ "MOUNTABLE" ],
+    "flags": [ "MOUNTABLE", "INITIAL_PART" ],
     "damage_reduction": { "all": 28 }
   }
 ]


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fixes vehicles being prevented to be constructed from all the frames."

#### Purpose of change

In the recent [pull request 42803](https://github.com/CleverRaven/Cataclysm-DDA/pull/42803) some frames missed out on their INITIAL_PART flags which were assigned in previous versions, which then disallowed these frames to function as a starting point for vehicle construction.

#### Describe the solution

This pull requests adds these missing flags back in, as a vehicle like a wooden cart or a light bike should not require a piece of steel frame to start with.
It also replaces the remaining "abstract" with an "id", as it does not seem to be in use as an abstract anymore.

#### Describe alternatives you've considered

Sit back and watch the world burn...

#### Testing

As for testing... I've verified that the parts show up in the start vehicle construction option and that they can be used as a starting point.
I've also run some tests with the light wooden frame (abstract to id change) to make sure I didn't messed things up there.

#### Additional context

There's still a bug that will make the frames not show up in the vehicle installation menu, but that is unrelated to this pull request.